### PR TITLE
Implement test watcher

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -21,5 +21,6 @@ Test.works = 'insideProject';
 Test.availableOptions = [
   { name: 'watch', type: Boolean, default: false, aliases: ['w'] }
 ];
+Test.parameters = [];
 
 module.exports = Test;

--- a/lib/models/tester.js
+++ b/lib/models/tester.js
@@ -10,11 +10,7 @@ let Watcher     = require('./watcher'),
 
 class Tester {
   test(args) {
-    let resolvePromise = this._promisizeResolve('babel-core/register'),
-        files = mochaUtils.lookupFiles('app/tests', ['js','jsx'], true);
-
-    files = files.map(f => path.resolve(f));
-    mocha.files = files;
+    let resolvePromise = this._promisizeResolve('babel-core/register');
 
     return resolvePromise.then((babelCoreRegister) => {
       require(babelCoreRegister);
@@ -32,9 +28,7 @@ class Tester {
             delete require.cache[f];
           });
 
-          mocha.grep(null);
-          mocha.suite = mocha.suite.clone();
-          mocha.suite.ctx = new Mocha.Context;
+          Mocha.call(mocha, mocha.options);
           this._test();
         });
       }
@@ -42,6 +36,9 @@ class Tester {
   }
 
   _test() {
+    let files = mochaUtils.lookupFiles('app/tests', ['js','jsx'], true);
+    files = files.map(f => path.resolve(f));
+    mocha.files = files;
     mocha.run();
   }
 

--- a/lib/models/tester.js
+++ b/lib/models/tester.js
@@ -1,6 +1,7 @@
 'use strict';
 
-let Mocha       = require('mocha/lib/mocha'),
+let Watcher     = require('./watcher'),
+    Mocha       = require('mocha/lib/mocha'),
     mochaUtils  = require('mocha/lib/utils'),
     path        = require('path'),
     resolver    = require('resolve'),
@@ -8,18 +9,40 @@ let Mocha       = require('mocha/lib/mocha'),
     mocha       = new Mocha();
 
 class Tester {
-  test() {
-    let resolvePromise = this._promisizeResolve('babel-core/register');
+  test(args) {
+    let resolvePromise = this._promisizeResolve('babel-core/register'),
+        files = mochaUtils.lookupFiles('app/tests', ['js','jsx'], true);
+
+    files = files.map(f => path.resolve(f));
+    mocha.files = files;
 
     return resolvePromise.then((babelCoreRegister) => {
       require(babelCoreRegister);
     }).then(() => {
-      let files = mochaUtils.lookupFiles('app/tests', ['js','jsx'], true);
-      files = files.map(f => path.resolve(f));
+      let watchFiles = mochaUtils.files(
+        path.join(process.cwd(), 'app'),
+        ['js', 'jsx']
+      );
 
-      mocha.files = files;
-      mocha.run();
+      this._test();
+
+      if(args.watch) {
+        let watcher = new Watcher('app', () => {
+          watchFiles.forEach(f => {
+            delete require.cache[f];
+          });
+
+          mocha.grep(null);
+          mocha.suite = mocha.suite.clone();
+          mocha.suite.ctx = new Mocha.Context;
+          this._test();
+        });
+      }
     });
+  }
+
+  _test() {
+    mocha.run();
   }
 
   _promisizeResolve(p) {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -6,7 +6,7 @@ let Task    = require('../models/task'),
 class Test extends Task {
   run(args) {
     let tester = new Tester();
-    return tester.test();
+    return tester.test(args);
   }
 }
 


### PR DESCRIPTION
This PR implements the `--watch` option for the test runner.

Rather than use the built-in `watch` in `mochaUtils`, I've implemented it using our `Watcher` instead.
